### PR TITLE
Add OVS datapath type to port profile

### DIFF
--- a/nova/network/os_vif_util.py
+++ b/nova/network/os_vif_util.py
@@ -280,7 +280,8 @@ def _nova_to_osvif_vif_bridge(vif):
 def _nova_to_osvif_vif_ovs(vif):
     vnic_type = vif.get('vnic_type', model.VNIC_TYPE_NORMAL)
     profile = objects.vif.VIFPortProfileOpenVSwitch(
-        interface_id=vif.get('ovs_interfaceid') or vif['id'])
+        interface_id=vif.get('ovs_interfaceid') or vif['id'],
+        datapath_type=vif['details'].get('datapath_type'))
     if vnic_type == model.VNIC_TYPE_DIRECT:
         profile = objects.vif.VIFPortProfileOVSRepresentor(
             interface_id=vif.get('ovs_interfaceid') or vif['id'],


### PR DESCRIPTION
Open vSwitch can have different datapath types configured
and is required by the VIF plug plugin when setting up
the bridge.  Adding the datapath type to the VIF port profile
permits the proper value to be configured when configuring
the port.

Story: 2002567