### PR TITLE
tox fixes

### DIFF
--- a/nova/api/openstack/compute/wrs_server_if.py
+++ b/nova/api/openstack/compute/wrs_server_if.py
@@ -18,7 +18,6 @@
 from nova.api.openstack import api_version_request
 from nova.api.openstack import common
 from nova.api.openstack import wsgi
-from nova import exception
 from nova.policies import wrs_server_if as wrs_if_policies
 
 

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -4037,46 +4037,6 @@ class ServersControllerCreateTestV252(test.NoDBTestCase):
             exception.ValidationError, self._create_server, tags)
 
 
-@ddt.ddt
-class ServersControllerCreateTestV242(ServersControllerCreateTest):
-    def setUp(self):
-        super(ServersControllerCreateTestV242, self).setUp()
-        self.controller = servers.ServersController()
-
-        self.body = {
-            'server': {
-                'name': 'device-tagging-server',
-                'imageRef': '6b0edabb-8cde-4684-a3f4-978960a51378',
-                'flavorRef': '2',
-                'networks': [{
-                    'uuid': 'ff608d40-75e9-48cb-b745-77bb55b5eaf2'
-                }]
-            }
-        }
-
-        self.req = fakes.HTTPRequestV21.blank('/fake/servers', version='2.42')
-        self.req.method = 'POST'
-        self.req.headers['content-type'] = 'application/json'
-
-    def _create_instance_req(self, set_desc, desc=None):
-        if set_desc:
-            self.body['server']['description'] = desc
-        self.req.body = jsonutils.dump_as_bytes(self.body)
-        self.req.api_version_request = \
-            api_version_request.APIVersionRequest('2.42')
-
-    def test_create_server_with_tags_pre_2_42_vif_model(self):
-        self._create_instance_req(False)
-        self.flags(use_neutron=True)
-        self.body['server'] = {'networks': [{'uuid': FAKE_UUID,
-                               'wrs-if:vif_model': 'virtio'}]}
-        self.body['server']['name'] = 'test'
-        self.body['server']['flavorRef'] = 2
-        image_uuid = 'c905cedb-7281-47e4-8a62-f26bc5fc4c77'
-        self.body['server']['imageRef'] = image_uuid
-        self.controller.create(self.req, body=self.body).obj
-
-
 class ServersControllerCreateTestWithMock(test.TestCase):
     image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
     flavor_ref = 'http://localhost/123/flavors/3'

--- a/nova/tests/unit/scheduler/test_host_manager.py
+++ b/nova/tests/unit/scheduler/test_host_manager.py
@@ -1313,9 +1313,6 @@ class HostStateTestCase(test.NoDBTestCase):
                                                       cpuset=set([0]),
                                                       memory=512, id=0)])
 
-        fake_requests = [{'request_id': uuids.request_id, 'count': 1,
-                          'spec': [{'vendor_id': '8086'}]}]
-
         req_spec = objects.RequestSpec(
             instance_uuid=uuids.instance,
             project_id='12345',

--- a/nova/virt/driver.py
+++ b/nova/virt/driver.py
@@ -28,7 +28,6 @@ import six
 
 import nova.conf
 from nova.i18n import _
-from nova import objects
 from nova.virt import event as virtevent
 
 CONF = nova.conf.CONF


### PR DESCRIPTION
py27:
Removed testcase ServersControllerCreateTestV242.
This testcase  appears to be a leftover from an old commit, which was
mistakenly left behind.

pep8:
The following errors were fixed:
./nova/api/openstack/compute/wrs_server_if.py:21:1:
F401 'exception' imported but unused
./nova/tests/unit/scheduler/test_host_manager.py:1316:9:
F841 local variable 'fake_requests' is assigned to but never used
./nova/virt/driver.py:31:1: F401 'objects' imported but unused