### PR TITLE
Restored Support for configurable pci bus slots for guest vnics

### DIFF
--- a/nova/api/openstack/common.py
+++ b/nova/api/openstack/common.py
@@ -369,9 +369,13 @@ def get_nics_for_instance_from_nw_info(nw_info):
     nics = []
     for index, vif in enumerate(nw_info):
         name = "nic" + str(index + 1)
+        vif_pci_address = ""
+        if vif.get('profile') is not None:
+            vif_pci_address = vif.get('profile', {}).get('vif_pci_address', "")
         nics.append({name: {'port_id': vif['id'],
                             'mac_address': vif['address'],
                             'vif_model': vif['vif_model'],
+                            'vif_pci_address': vif_pci_address,
                             'mtu': vif['mtu'],
                             'network': vif['network']['label']}})
     return nics

--- a/nova/api/openstack/compute/schemas/servers.py
+++ b/nova/api/openstack/compute/schemas/servers.py
@@ -75,9 +75,11 @@ base_create_v20['properties']['server'][
 base_create_v219 = copy.deepcopy(base_create)
 base_create_v219['properties']['server'][
     'properties']['description'] = parameter_types.description
-# WRS: add vif_model to networks properties for v2.19
+# WRS: add vif_model and vif_pci_address to networks properties for v2.19
 base_create_v219['properties']['server']['properties']['networks'][
     'items']['properties']['wrs-if:vif_model'] = {'enum': model.VIF_MODEL_ALL}
+base_create_v219['properties']['server']['properties']['networks'][
+    'items']['properties']['wrs-if:vif_pci_address'] = {'type': 'string'}
 
 
 base_create_v232 = copy.deepcopy(base_create_v219)
@@ -104,8 +106,10 @@ base_create_v237['properties']['server']['properties']['networks'] = {
                                {'type': 'null'}]
                  },
                  'uuid': {'type': 'string', 'format': 'uuid'},
-                 # WRS: add vif_model to networks properties for v2.37
+                 # WRS: add vif_model and vif_pci_address to networks
+                 # properties for v2.37
                  'wrs-if:vif_model': {'enum': model.VIF_MODEL_ALL},
+                 'wrs-if:vif_pci_address': {'type': 'string'},
              },
              'additionalProperties': False,
          },
@@ -130,9 +134,10 @@ base_create_v242['properties']['server']['properties']['networks'] = {
                  },
                  'uuid': {'type': 'string', 'format': 'uuid'},
                  'tag': parameter_types.tag,
-                  # WRS: add vif_model
+                 # WRS: add vif_model and vif_pci_address
                  'wrs-if:vif_model': {'type': 'string',
                                       'enum': model.VIF_MODEL_ALL},
+                 'wrs-if:vif_pci_address': {'type': 'string'},
              },
              'additionalProperties': False,
          },

--- a/nova/objects/network_request.py
+++ b/nova/objects/network_request.py
@@ -34,9 +34,9 @@ NETWORK_ID_AUTO = 'auto'
 class NetworkRequest(obj_base.NovaObject):
     # Version 1.0: Initial version
     # Version 1.1: Added pci_request_id
+    #              WRS: Added vif_model & vif_pci_address
     # Version 1.2: Added tag field
     VERSION = '1.2'
-    #              WRS: Added vif_model
     fields = {
         'network_id': fields.StringField(nullable=True),
         'address': fields.IPAddressField(nullable=True),
@@ -44,6 +44,7 @@ class NetworkRequest(obj_base.NovaObject):
         'pci_request_id': fields.UUIDField(nullable=True),
         'tag': fields.StringField(nullable=True),
         'vif_model': fields.StringField(nullable=True),
+        'vif_pci_address': fields.StringField(nullable=True),
     }
 
     def obj_make_compatible(self, primitive, target_version):
@@ -58,13 +59,19 @@ class NetworkRequest(obj_base.NovaObject):
         address = str(self.address) if self.address is not None else None
         if utils.is_neutron():
             return (self.network_id, address, self.port_id,
-                    self.pci_request_id, self.vif_model)
+                    self.pci_request_id, self.vif_model, self.vif_pci_address)
         else:
             return self.network_id, address
 
     @classmethod
     def from_tuple(cls, net_tuple):
-        if len(net_tuple) == 5:
+        if len(net_tuple) == 6:
+            network_id, address, port_id, pci_request_id, vif_model, \
+                vif_pci_address = net_tuple
+            return cls(network_id=network_id, address=address,
+                       port_id=port_id, pci_request_id=pci_request_id,
+                       vif_model=vif_model, vif_pci_address=vif_pci_address)
+        elif len(net_tuple) == 5:
             network_id, address, port_id, pci_request_id, vif_model = net_tuple
             return cls(network_id=network_id, address=address,
                        port_id=port_id, pci_request_id=pci_request_id,

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -218,14 +218,14 @@ class ServersControllerTest(ControllerTest):
         uuid = 'br-00000000-0000-0000-0000-000000000000'
         requested_networks = [{'uuid': uuid}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertIn((uuid, None, None, None, None), res.as_tuples())
+        self.assertIn((uuid, None, None, None, None, None), res.as_tuples())
 
     def test_requested_networks_neutronv2_enabled_with_port(self):
         self.flags(use_neutron=True)
         port = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
         requested_networks = [{'port': port}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(None, None, port, None, None)],
+        self.assertEqual([(None, None, port, None, None, None)],
                          res.as_tuples())
 
     def test_requested_networks_neutronv2_enabled_with_network(self):
@@ -233,7 +233,7 @@ class ServersControllerTest(ControllerTest):
         network = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         requested_networks = [{'uuid': network}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(network, None, None, None, None)],
+        self.assertEqual([(network, None, None, None, None, None)],
                          res.as_tuples())
 
     # WRS: add testcase for wrs-if:vif_model
@@ -242,7 +242,7 @@ class ServersControllerTest(ControllerTest):
         network = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         requested_networks = [{'uuid': network, 'wrs-if:vif_model': 'virtio'}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(network, None, None, None, 'virtio')],
+        self.assertEqual([(network, None, None, None, 'virtio', None)],
                          res.as_tuples())
 
     def test_requested_networks_neutronv2_enabled_with_network_and_port(self):
@@ -251,7 +251,7 @@ class ServersControllerTest(ControllerTest):
         port = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
         requested_networks = [{'uuid': network, 'port': port}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(None, None, port, None, None)],
+        self.assertEqual([(None, None, port, None, None, None)],
                          res.as_tuples())
 
     def test_requested_networks_with_duplicate_networks_nova_net(self):
@@ -270,8 +270,8 @@ class ServersControllerTest(ControllerTest):
         network = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         requested_networks = [{'uuid': network}, {'uuid': network}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(network, None, None, None, None),
-                          (network, None, None, None, None)],
+        self.assertEqual([(network, None, None, None, None, None),
+                          (network, None, None, None, None, None)],
                          res.as_tuples())
 
     def test_requested_networks_neutronv2_enabled_conflict_on_fixed_ip(self):
@@ -302,7 +302,7 @@ class ServersControllerTest(ControllerTest):
         port = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'
         requested_networks = [{'uuid': network, 'port': port}]
         res = self.controller._get_requested_networks(requested_networks)
-        self.assertEqual([(None, None, port, None, None)],
+        self.assertEqual([(None, None, port, None, None, None)],
                          res.as_tuples())
 
     def test_get_server_by_uuid(self):
@@ -2997,7 +2997,7 @@ class ServersControllerCreateTest(test.TestCase):
 
         def create(*args, **kwargs):
             result = [('76fa36fc-c930-4bf3-8c8a-ea2a2420deb6', None,
-                       None, None, None)]
+                       None, None, None, None)]
             self.assertEqual(result, kwargs['requested_networks'].as_tuples())
             return old_create(*args, **kwargs)
 

--- a/nova/tests/unit/api/openstack/compute/test_wrs_server_if.py
+++ b/nova/tests/unit/api/openstack/compute/test_wrs_server_if.py
@@ -79,6 +79,7 @@ for index, cache in enumerate(NW_CACHE):
     nic = {name: {'port_id': cache['id'],
                   'mac_address': cache['address'],
                   'vif_model': cache['vif_model'],
+                  'vif_pci_address': '',
                   'mtu': None,  # only available from neutron in real env
                   'network': cache['network']['label']}}
     ALL_NICS.append(nic)

--- a/nova/tests/unit/objects/test_network_request.py
+++ b/nova/tests/unit/objects/test_network_request.py
@@ -46,7 +46,7 @@ class _TestNetworkRequestObject(object):
                                          port_id=FAKE_UUID,
                                      )
         with mock.patch('nova.utils.is_neutron', return_value=True):
-            self.assertEqual(('123', '1.2.3.4', FAKE_UUID, None, None),
+            self.assertEqual(('123', '1.2.3.4', FAKE_UUID, None, None, None),
                              request.to_tuple())
 
     def test_to_tuple_nova(self):
@@ -80,7 +80,8 @@ class _TestNetworkRequestObject(object):
             objects=[objects.NetworkRequest(network_id='123'),
                      objects.NetworkRequest(network_id='456')])
         self.assertEqual(
-            [('123', None, None, None, None), ('456', None, None, None, None)],
+            [('123', None, None, None, None, None),
+             ('456', None, None, None, None, None)],
              requests.as_tuples())
 
     def test_is_single_unspecified(self):

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1142,7 +1142,7 @@ object_data = {
     'Network': '1.2-a977ab383aa462a479b2fae8211a5dde',
     'NetworkInterfaceMetadata': '1.1-3269ce11b30531eb1febfa5173b78b81',
     'NetworkList': '1.2-69eca910d8fa035dfecd8ba10877ee59',
-    'NetworkRequest': '1.2-3eeb5369745665f03fe792cf5d25eda4',
+    'NetworkRequest': '1.2-a765c8f0c0800ef704b83e4242ea50d2',
     'NetworkRequestList': '1.1-15ecf022a68ddbb8c2a6739cfc9f8f5e',
     'PciDevice': '1.6-5411e27b90bfe6e82c53454490bdf467',
     'PCIDeviceBus': '1.0-2b891cb77e42961044689f3dc2718995',

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -2035,7 +2035,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual(cfg.os_type, fields.VMMode.HVM)
         self.assertEqual(cfg.os_boot_dev, ["hd"])
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(len(cfg.devices), 10)
+        self.assertEqual(len(cfg.devices), 11)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -2146,7 +2146,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual("console=tty0 console=ttyS0 console=hvc0",
                          cfg.os_cmdline)
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(3, len(cfg.devices))
+        self.assertEqual(4, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestFilesys)
         self.assertIsInstance(cfg.devices[1],
@@ -2172,7 +2172,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual("console=tty0 console=ttyS0 console=hvc0",
                          cfg.os_cmdline)
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(3, len(cfg.devices))
+        self.assertEqual(4, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestFilesys)
         self.assertIsInstance(cfg.devices[1],
@@ -3385,7 +3385,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual(cfg.os_type, fields.VMMode.HVM)
         self.assertEqual(cfg.os_boot_dev, ["hd"])
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(len(cfg.devices), 10)
+        self.assertEqual(len(cfg.devices), 11)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3450,7 +3450,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual(cfg.os_type, "uml")
         self.assertEqual(cfg.os_boot_dev, [])
         self.assertEqual(cfg.os_root, '/dev/vdb')
-        self.assertEqual(len(cfg.devices), 3)
+        self.assertEqual(len(cfg.devices), 4)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3721,7 +3721,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 7)
+        self.assertEqual(len(cfg.devices), 8)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3757,7 +3757,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3798,7 +3798,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3839,7 +3839,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -3982,7 +3982,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(8, len(cfg.devices))
+        self.assertEqual(9, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4018,7 +4018,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(10, len(cfg.devices))
+        self.assertEqual(11, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4078,7 +4078,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [], image_meta,
                                      disk_info)
-        self.assertEqual(10, len(cfg.devices), cfg.devices)
+        self.assertEqual(11, len(cfg.devices), cfg.devices)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4320,7 +4320,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 6)
+        self.assertEqual(len(cfg.devices), 7)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4461,7 +4461,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 10)
+        self.assertEqual(len(cfg.devices), 11)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4503,7 +4503,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             image_meta)
 
         cfg = drvr._get_guest_config(instance_ref, [], image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 9)
+        self.assertEqual(len(cfg.devices), 10)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4657,7 +4657,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
 
-        self.assertEqual(9, len(cfg.devices))
+        self.assertEqual(10, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4697,7 +4697,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
 
-        self.assertEqual(9, len(cfg.devices))
+        self.assertEqual(10, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4732,7 +4732,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             instance_ref,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [], image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4766,7 +4766,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             instance_ref,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [], image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 9)
+        self.assertEqual(len(cfg.devices), 10)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4812,7 +4812,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4938,7 +4938,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
                                             instance_ref,
                                             image_meta)
         cfg = drvr._get_guest_config(instance_ref, [], image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -4976,7 +4976,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -5015,7 +5015,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 7)
+        self.assertEqual(len(cfg.devices), 8)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -5050,7 +5050,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -5094,7 +5094,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
 
         cfg = drvr._get_guest_config(instance_ref, [],
                                      image_meta, disk_info)
-        self.assertEqual(len(cfg.devices), 8)
+        self.assertEqual(len(cfg.devices), 9)
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertIsInstance(cfg.devices[1],
@@ -16302,7 +16302,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual(instance_ref.flavor.vcpus, cfg.vcpus)
         self.assertEqual(fields.VMMode.HVM, cfg.os_type)
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(6, len(cfg.devices))
+        self.assertEqual(7, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestDisk)
         self.assertEqual(cfg.devices[0].driver_format, "ploop")
@@ -16348,9 +16348,9 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual("/sbin/init", cfg.os_init_path)
         self.assertIsNone(cfg.os_root)
         if rescue:
-            self.assertEqual(5, len(cfg.devices))
+            self.assertEqual(6, len(cfg.devices))
         else:
-            self.assertEqual(4, len(cfg.devices))
+            self.assertEqual(5, len(cfg.devices))
         self.assertIsInstance(cfg.devices[0],
                               vconfig.LibvirtConfigGuestFilesys)
 
@@ -16412,7 +16412,7 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         self.assertEqual(instance_ref.flavor.vcpus, cfg.vcpus)
         self.assertEqual(vmmode, cfg.os_type)
         self.assertIsNone(cfg.os_root)
-        self.assertEqual(devices, len(cfg.devices))
+        self.assertEqual(devices + 1, len(cfg.devices))
 
         disk_found = False
 


### PR DESCRIPTION
This commit was inadvertently omitted when setting up stx-nova.

This feature introduces the capability to specify the guest PCI
addresses for network interfaces.

The REST API has been extended to support the new parameter
wrs-if:vif_pci_address when requesting a nic for a particular network.
The format of the PCI address is: <domain>:<bus>:<slot>.<function>.
However in this release it's not possible to specify a domain value
other than 0 (because of limitation in kvm/qemu) and a function value
other than 0 (this add complexity in the management of PCI devices for
the libvirt XML specification).

The possibility to specify the bus and the slot allows the user to
address a wide range of devices within it's guest (bus is a 16 bits
value and slot is a 5 bits value). If a bus number greater than 0 is
specified, the corresponding pci-bridges will be configured in the
libvirt XML.

The virtual PCI address is persisted in the associated Neutron port in
the profile field.

Additionaly, set pci controller pcihole64 attribute to 64 GiB: This
looks at the os_type of an instance, and if it is windows, then the
pcihole64 attribute is set to 64 GiB.

In the case of windows guests however, if we allocate this space, then
the guest will fail to boot.  As such, we discriminate based on os_type,
and do not allocate this in the case of windows guests.

Limitations:
- This feature only support PCI devices of type NIC. Other PCI devices
  that can be specified with a flavor is not supported.

Ported from internal commit bf5593bb752f59edcec7ea9c0569e1952eb6155d

StoryBoard:2002877 Task:22839
https://storyboard.openstack.org/#!/story/2002877

Testing:
All nova tox py27 and pep8 tests were run.
Code compiled, built, and run on a hardware lab. Verify that the described functionality is back.
