### PR TITLE
Align floating cpusets base path to openstack-helm cgroup default

### DIFF
--- a/nova/virt/hardware.py
+++ b/nova/virt/hardware.py
@@ -44,7 +44,7 @@ MEMPAGES_LARGE = -2
 MEMPAGES_ANY = -3
 
 # WRS base path used for floating instance cpusets
-CPUSET_BASE = '/dev/cpuset/floating'
+CPUSET_BASE = '/sys/fs/cgroup/cpuset/floating'
 
 
 # WRS - extra_specs, image_props helper functions


### PR DESCRIPTION
This changes the base path used for floating instance cpusets
to '/sys/fs/cgroup/cpuset/floating'. This aligns with the
openstack-helm default cgroup path, and has no functional change.

Story: 2003909
Task: 27081
Signed-off-by: Jim Gauld <james.gauld@windriver.com>