### PR TITLE
remove local storage default flavor extra-spec

### DIFF
--- a/nova/api/openstack/compute/flavor_manage.py
+++ b/nova/api/openstack/compute/flavor_manage.py
@@ -105,11 +105,6 @@ class FlavorManageController(wsgi.Controller):
                                     rxtx_factor=rxtx_factor,
                                     is_public=is_public)
 
-            # WRS: set local storage backend default to local_image
-            flavor.extra_specs = {
-                'aggregate_instance_extra_specs:storage': 'local_image'}
-            flavor.save()
-
             # NOTE(gmann): For backward compatibility, non public flavor
             # access is not being added for created tenant. Ref -bug/1209101
             req.cache_db_flavor(flavor)

--- a/nova/tests/unit/api/openstack/compute/test_flavor_manage.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_manage.py
@@ -44,10 +44,6 @@ def fake_create(newflavor):
     newflavor["disabled"] = False
 
 
-def fake_save(context):
-    pass
-
-
 class FlavorManageTestV21(test.NoDBTestCase):
     controller = flavormanage_v21.FlavorManageController()
     validation_error = exception.ValidationError
@@ -56,8 +52,6 @@ class FlavorManageTestV21(test.NoDBTestCase):
     def setUp(self):
         super(FlavorManageTestV21, self).setUp()
         self.stub_out("nova.objects.Flavor.create", fake_create)
-        # WRS: stub out flavor save
-        self.stub_out("nova.objects.Flavor.save", fake_save)
 
         self.request_body = {
             "flavor": {


### PR DESCRIPTION
Going forward we do not want to carry the change to default to local
image storage, so pull it out.

Operators that have a mix of local and remote storage will need to
set up flavor extra-specs and host aggregates themselves.

Story: 2004386
Task: 28006
Signed-off-by: Chris Friesen <chris.friesen@windriver.com>