### PR TITLE
update 'hw:cpu_model' meta data to support *-IBRS vcpu type

### DIFF
--- a/nova/objects/fields.py
+++ b/nova/objects/fields.py
@@ -347,14 +347,23 @@ class CPUModel(BaseNovaEnum):
            "Conroe",
            "Penryn",
            "Nehalem",
+           "Nehalem-IBRS",
            "Westmere",
+           "Westmere-IBRS",
            "SandyBridge",
+           "SandyBridge-IBRS",
            "IvyBridge",
+           "IvyBridge-IBRS",
            "Haswell",
+           "Haswell-IBRS",
            "Broadwell-noTSX",
+           "Broadwell-noTSX-IBRS",
            "Broadwell",
+           "Broadwell-IBRS",
            "Skylake-Client",
-           "Skylake-Server")
+           "Skylake-Client-IBRS",
+           "Skylake-Server",
+           "Skylake-Server-IBRS")
 
 
 class CPUMatch(BaseNovaEnum):

--- a/nova/scheduler/filters/vcpu_model_filter.py
+++ b/nova/scheduler/filters/vcpu_model_filter.py
@@ -49,6 +49,12 @@ class VCpuModelFilter(filters.BaseHostFilter):
             # The guest CPU model is not in our list.  We can't tell whether
             # we can support it or not.
             return False
+
+        # if guest request IBRS cpu, but host does not support 'IBRS', then 
+        # return false directly
+        if('IBRS' in guest and 'IBRS' not in host):
+            return False
+
         return bool(guest_index <= host_index)
 
     def _passthrough_host_passes(self, host_state, spec_obj):


### PR DESCRIPTION
after libvirt upgraded to 4.7.0, there are some new vcpu types for
instance vcpu_model, if compute node is using *-IBRS cpu,
Passthrough favor can not be used for creating instance.
it will cause some like below error
"No valid host was found. There are not enough hosts available.
 computer-0: (VCpuModelFilter) Host VCPU model Skylake-Server-IBRS
 required Passthrough
 Code 501"

filter return false guest request 'IBRS type CPU'
if host does not support "IBRS"

Closes-Bug: 1803280

Signed-off-by: Sun Austin <austin.sun@intel.com>