### PR TITLE
Conditionally map compute hosts when created

### DIFF
--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -917,7 +917,8 @@ class ResourceTracker(object):
         cn = objects.ComputeNode(context)
         cn.host = self.host
         # WRS: host mapping is already done at service_create
-        cn.mapped = 1
+        if CONF.map_new_hosts:
+            cn.mapped = 1
         self._copy_resources(cn, resources)
         self.compute_nodes[nodename] = cn
         cn.create()

--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -1181,6 +1181,19 @@ Possible values:
   or with the CLI with ``nova service-enable <hostname> <binary>``, otherwise
   they are not ready to use.
 """),
+    cfg.BoolOpt('map_new_hosts',
+        default=True,
+        help="""
+Map a host when creating its Compute Node.
+
+Add an entry in nova_api host_mappings table for
+the compute node while creating host service.
+
+Possible values:
+
+* ``True``: map a new host when its Compute Node object is created.
+* ``False``: Do not map a new host when its Compute Node object is created.
+"""),
     cfg.StrOpt('instance_name_template',
          default='instance-%08x',
          help="""

--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -2948,4 +2948,3 @@ class LibvirtConfigGuestvTPMDevice(LibvirtConfigGuestQemuRawDevice):
         self.add_argument(value)
 
         return super(LibvirtConfigGuestvTPMDevice, self).format_dom()
-


### PR DESCRIPTION
Map compute hosts only if map_new_hosts is set to True.
This is needed to remove the current StarlingX nova extension that
allows nova services to be created before the service is actually
running.
Cosmetic change to libvirt/config.py to allow pep8 to succeed
This is a temporary change that will no longer be needed when stx
moves to Stein.

Story: 2004583
Task: 28387