### PR TITLE
Add low latency per-cpu power management

### DIFF
--- a/nova/scheduler/filters/vcpu_model_filter.py
+++ b/nova/scheduler/filters/vcpu_model_filter.py
@@ -50,7 +50,7 @@ class VCpuModelFilter(filters.BaseHostFilter):
             # we can support it or not.
             return False
 
-        # if guest request IBRS cpu, but host does not support 'IBRS', then 
+        # if guest request IBRS cpu, but host does not support 'IBRS', then
         # return false directly
         if('IBRS' in guest and 'IBRS' not in host):
             return False

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -1102,7 +1102,7 @@ object_data = {
     'HVSpec': '1.2-de06bcec472a2f04966b855a49c46b41',
     'IDEDeviceBus': '1.0-29d4c9f27ac44197f01b6ac1b7e16502',
     'ImageMeta': '1.8-642d1b2eb3e880a367f37d72dd76162d',
-    'ImageMetaProps': '1.19-bab16fcd5635fc87254904e97ca379a4',
+    'ImageMetaProps': '1.19-b189e6ca5c27324d46e8c4398b0e7b86',
     'Instance': '2.3-4ceb84ca0991892b74bd8f91a3418526',
     'InstanceAction': '1.1-f9f293e526b66fca0d05c3b3a2d13914',
     'InstanceActionEvent': '1.1-cc5342ce9da679b9ee3f704cbbfbb63f',

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -15422,15 +15422,11 @@ class LibvirtConnTestCase(test.NoDBTestCase,
         for fs in supported_fs:
             self.assertFalse(drvr.is_supported_fs_format(fs))
 
-    @mock.patch('nova.objects.instance.Instance.obj_load_attr')
-    @mock.patch('nova.virt.libvirt.driver.LibvirtDriver._set_cpu_latency')
     @mock.patch('nova.virt.libvirt.host.Host.write_instance_config')
     @mock.patch('nova.virt.libvirt.host.Host.get_guest')
     def test_post_live_migration_at_destination(
-            self, mock_get_guest, mock_write_instance_config,
-            mock_cpulatency, mock_loadattr):
+            self, mock_get_guest, mock_write_instance_config):
         instance = objects.Instance(id=1, uuid=uuids.instance)
-        instance.numa_topology = objects.InstanceNUMATopology()
         dom = mock.MagicMock()
         dom.XMLDesc.return_value = "<domain></domain>"
         guest = libvirt_guest.Guest(dom)

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -80,9 +80,6 @@ TIME_UNITS = {
 
 
 _IS_NEUTRON = None
-_IS_LOWLATENCY = None
-
-PLATFORM_CONF = "/etc/platform/platform.conf"
 
 synchronized = lockutils.synchronized_with_prefix('nova-')
 
@@ -1289,29 +1286,6 @@ def is_neutron():
 
     _IS_NEUTRON = nova.network.is_neutron()
     return _IS_NEUTRON
-
-
-def is_host_lowlatency():
-    global _IS_LOWLATENCY
-
-    if _IS_LOWLATENCY is not None:
-        return _IS_LOWLATENCY
-
-    _IS_LOWLATENCY = _get_host_lowlatency_info()
-    return _IS_LOWLATENCY
-
-
-def _get_host_lowlatency_info():
-    try:
-        with open(PLATFORM_CONF) as f:
-            for line in f:
-                if 'subfunction' in line:
-                    return 'lowlatency' in line
-
-    except IOError as e:
-        LOG.error('Cannot open: %(file)s, error = %(err)s',
-                  {'file': PLATFORM_CONF, 'err': e})
-    return False
 
 
 def is_auto_disk_config_disabled(auto_disk_config_raw):


### PR DESCRIPTION
Refactor low latency compute per-cpu power management
out of stx-nova into libvirt qemu hook
Includes cosmetic changes to allow tox pep8 to succeed

Story: 2004610
Task: 28508

Signed-off-by: Daniel Chavolla <daniel.chavolla@windriver.com>